### PR TITLE
Correct missing s3MessageKey for setting S3 object

### DIFF
--- a/src/ExtendedSqsClient.js
+++ b/src/ExtendedSqsClient.js
@@ -249,6 +249,7 @@ class ExtendedSqsClient {
         let s3MessageKey;
 
         if (!sendObj.s3Content || existingS3MessageKey) {
+            s3MessageKey = existingS3MessageKey
             sendParams.MessageBody = sendObj.messageBody || existingS3MessageKey.StringValue;
         } else {
             s3MessageKey = uuidv4();


### PR DESCRIPTION
The s3MessageKey will be used as S3 object key, and upon empty, the object won't be created.